### PR TITLE
Porting plugin to OJS 3.3

### DIFF
--- a/CacheBusterPlugin.inc.php
+++ b/CacheBusterPlugin.inc.php
@@ -12,9 +12,7 @@
  * @brief Clear the CSS and Template cache on every page load.
  */
 
-use APP\core\Application;
-use PKP\cache\CacheManager;
-use PKP\plugins\GenericPlugin;
+import('lib.pkp.classes.plugins.GenericPlugin');
 
 class CacheBusterPlugin extends GenericPlugin {
 	/**


### PR DESCRIPTION
This fix adjusts the plugin to run under OJS3.3 using the latest syntax: import().